### PR TITLE
preserve CMD-style directory filters in URL handling

### DIFF
--- a/lib/device/iec/drive.cpp
+++ b/lib/device/iec/drive.cpp
@@ -672,8 +672,18 @@ bool iecDrive::open(uint8_t channel, const char *cname)
                 close(channel);
             }
 
-            if ( name[0] == '$' ) 
-                name.clear();
+            // Handle CMD-style directory filters by preserving them in URL
+            if ( name[0] == '$' ) {
+                // Check if this is a CMD-style filter (e.g., $=P, $GAME*, $=P:GAME*)
+                if (name.length() > 1 && (name[1] == '=' || isalnum(name[1]))) {
+                    // This looks like a CMD filter - preserve it for the server
+                    Debug_printv("CMD filter detected: [%s]", name.c_str());
+                    // Don't clear the name - let the server handle CMD filtering
+                } else {
+                    // Plain "$" - traditional directory listing
+                    name.clear();
+                }
+            }
 
             // get file
             Debug_printv( ANSI_MAGENTA_BOLD_HIGH_INTENSITY "Changing directory to [%s][%s]", m_cwd->url.c_str(), name.c_str());


### PR DESCRIPTION
This pull request improves the handling of CMD-style directory filters in the `iecDrive::open` method to ensure better compatibility and functionality when interacting with directory listings. The main change is to preserve CMD-style filters in the URL so that the server can process them, while still handling traditional directory listings as before.

Directory filter handling:

* Updated the logic in `iecDrive::open` to detect CMD-style directory filters (e.g., `$=P`, `$GAME*`) and preserve them in the URL for the server, instead of clearing the name as with a plain ` for traditional listings.