### PR TITLE
fix: two calls to strcpy() in untgz in untgz.c

### DIFF
--- a/components/zlib/zlib/contrib/untgz/untgz.c
+++ b/components/zlib/zlib/contrib/untgz/untgz.c
@@ -133,12 +133,12 @@ char *TGZfname (const char *arcname)
   static char buffer[1024];
   int origlen,i;
 
-  strcpy(buffer,arcname);
+  snprintf(buffer, sizeof(buffer), "%s", arcname);
   origlen = strlen(buffer);
 
   for (i=0; TGZsuffix[i]; i++)
     {
-       strcpy(buffer+origlen,TGZsuffix[i]);
+       snprintf(buffer+origlen, sizeof(buffer)-origlen, "%s", TGZsuffix[i]);
        if (access(buffer,F_OK) == 0)
          return buffer;
     }
@@ -193,7 +193,7 @@ char *strtime (time_t *t)
   static char result[32];
 
   local = localtime(t);
-  sprintf(result,"%4d/%02d/%02d %02d:%02d:%02d",
+  snprintf(result,sizeof(result),"%4d/%02d/%02d %02d:%02d:%02d",
           local->tm_year+1900, local->tm_mon+1, local->tm_mday,
           local->tm_hour, local->tm_min, local->tm_sec);
   return result;
@@ -436,9 +436,7 @@ int tar (gzFile in,int action,int arg,int argc,char **argv)
 
           if (getheader == 1)
             {
-              strncpy(fname,buffer.header.name,SHORTNAMESIZE);
-              if (fname[SHORTNAMESIZE-1] != 0)
-                  fname[SHORTNAMESIZE] = 0;
+              snprintf(fname,SHORTNAMESIZE+1,"%s",buffer.header.name);
             }
           else
             {


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `components/zlib/zlib/contrib/untgz/untgz.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `components/zlib/zlib/contrib/untgz/untgz.c:136` |

**Description**: Two calls to strcpy() in untgz.c perform no bounds checking. At line 136, strcpy(buffer, arcname) copies the archive name into a fixed-size buffer without verifying that arcname fits within the buffer. At line 141, strcpy(buffer+origlen, TGZsuffix[i]) appends a suffix without checking remaining buffer capacity. Both operations can overflow the destination buffer if the input exceeds its allocated size, corrupting adjacent stack or heap memory.

## Changes
- `components/zlib/zlib/contrib/untgz/untgz.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
