### PR TITLE
Support DOS drive prefixes in directory requests

### DIFF
--- a/lib/device/iec/drive.cpp
+++ b/lib/device/iec/drive.cpp
@@ -19,6 +19,7 @@
 #if defined(BUILD_IEC)
 
 #include "drive.h"
+#include "drive_filename.h"
 
 #include <algorithm>
 #include <cstring>
@@ -1020,6 +1021,11 @@ bool iecDrive::open(uint8_t channel, const char *cname, uint8_t nameLen)
                              channel, m_cwd->url.c_str(), (unsigned long) stream->block_size);
                 return true;
             }
+
+            // "0:" and "1:" select a drive inside a Commodore DOS device;
+            // they are not part of the directory pattern and must not be
+            // confused with CMD's alphanumeric filters.
+            iecNormalizeDirectoryDrivePrefix(name);
 
             // Handle CMD-style directory filters by preserving them in URL
             bool wasDirListing = false;

--- a/lib/device/iec/drive_filename.h
+++ b/lib/device/iec/drive_filename.h
@@ -1,0 +1,23 @@
+#ifndef IEC_DRIVE_FILENAME_H
+#define IEC_DRIVE_FILENAME_H
+
+#include <string>
+
+// Commodore DOS directory requests may select drive 0 or 1 inside the IEC
+// device (for example "$0:*" or "$1:NAME*"). Meatloaf exposes one current
+// directory per IEC device, so the selector does not change the device or cwd;
+// remove it and let the existing "$", "$*", and CMD-filter handling process
+// the remainder of the request.
+inline bool iecNormalizeDirectoryDrivePrefix(std::string &name)
+{
+    if (name.size() >= 3 && name[0] == '$' &&
+        (name[1] == '0' || name[1] == '1') && name[2] == ':')
+    {
+        name.erase(1, 2);
+        return true;
+    }
+
+    return false;
+}
+
+#endif // IEC_DRIVE_FILENAME_H

--- a/test/native/test_drive_filename/test_drive_filename.cpp
+++ b/test/native/test_drive_filename/test_drive_filename.cpp
@@ -1,0 +1,75 @@
+#include <unity.h>
+
+#include <string>
+
+#include "../../../lib/device/iec/drive_filename.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+static void assertNormalizes(const char *input, const char *expected)
+{
+    std::string name(input);
+    TEST_ASSERT_TRUE(iecNormalizeDirectoryDrivePrefix(name));
+    TEST_ASSERT_EQUAL_STRING(expected, name.c_str());
+}
+
+static void assertUnchanged(const char *input)
+{
+    std::string name(input);
+    TEST_ASSERT_FALSE(iecNormalizeDirectoryDrivePrefix(name));
+    TEST_ASSERT_EQUAL_STRING(input, name.c_str());
+}
+
+void test_drive_zero_directory_requests_are_normalized(void)
+{
+    assertNormalizes("$0:", "$");
+}
+
+void test_drive_zero_wildcards_use_existing_directory_handling(void)
+{
+    assertNormalizes("$0:*", "$*");
+    assertNormalizes("$0:NAME*", "$NAME*");
+}
+
+void test_drive_one_directory_requests_are_normalized(void)
+{
+    assertNormalizes("$1:", "$");
+    assertNormalizes("$1:*", "$*");
+    assertNormalizes("$1:NAME*", "$NAME*");
+}
+
+void test_prefixed_cmd_filters_rejoin_existing_filter_handling(void)
+{
+    assertNormalizes("$0:=P", "$=P");
+    assertNormalizes("$1:=P:NAME*", "$=P:NAME*");
+}
+
+void test_existing_directory_forms_and_cmd_filters_are_unchanged(void)
+{
+    assertUnchanged("$");
+    assertUnchanged("$*");
+    assertUnchanged("$NAME*");
+    assertUnchanged("$=P");
+    assertUnchanged("$=P:NAME*");
+}
+
+void test_prefix_is_only_recognized_in_directory_requests(void)
+{
+    assertUnchanged("0:FILE");
+    assertUnchanged("1:FILE");
+    assertUnchanged("$2:*");
+    assertUnchanged("$0FILE");
+}
+
+int main(int argc, char **argv)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_drive_zero_directory_requests_are_normalized);
+    RUN_TEST(test_drive_zero_wildcards_use_existing_directory_handling);
+    RUN_TEST(test_drive_one_directory_requests_are_normalized);
+    RUN_TEST(test_prefixed_cmd_filters_rejoin_existing_filter_handling);
+    RUN_TEST(test_existing_directory_forms_and_cmd_filters_are_unchanged);
+    RUN_TEST(test_prefix_is_only_recognized_in_directory_requests);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

- Add support for Commodore-DOS directory requests containing `$0:` or `$1:`.
- Normalize these prefixes before the existing directory and filter handling.
- Preserve existing directory requests, CMD filters, filenames, and IEC device selection.
- Add regression tests for the filename normalization.

## Background

COMAL-80 sends directory requests such as `$0:*` or `$1:*`.

Meatloaf previously interpreted the digit after `$` as part of a filter or
filename. This could result in `FILE NOT FOUND` instead of returning the
directory.

Examples:

- `$0:` becomes `$`
- `$0:*` becomes `$*`
- `$0:NAME*` becomes `$NAME*`
- `$1:=P:NAME*` becomes `$=P:NAME*`

Other requests remain unchanged.

## Testing

- Tested successfully with COMAL-80 on a C128 and Meatloaf on an ESP32-S3.
- `CAT` and `DIR` display Meatloaf directories correctly.
- Native Unity regression tests: 6 passed, 0 failed.
- Existing `$`, `$*`, CMD filters, filenames, and unsupported prefixes remain unchanged.