### PR TITLE
iecDrive: report DRIVE NOT READY when offline, not FILE NOT FOUND

### DIFF
--- a/lib/device/iec/drive.cpp
+++ b/lib/device/iec/drive.cpp
@@ -30,6 +30,7 @@
 #include "make_unique.h"
 
 #include "meatloaf.h"
+#include "fnWiFi.h"      // fnWiFi.connected() -- tell "offline" from "not found"
 #include "meat_session.h"
 #include "network/http.h"
 #include "mlConfig.h"
@@ -1155,8 +1156,7 @@ bool iecDrive::open(uint8_t channel, const char *cname, uint8_t nameLen)
                     // opening a file
                     if( (mode == std::ios_base::in) && !f->exists() )
                     {
-                        Debug_printv("Error: file doesn't exist [%s]", f->url.c_str());
-                        setStatusCode(ST_FILE_NOT_FOUND);
+                        setStatusFileError(f->url);
                     }
                     else if( (mode == std::ios_base::out) && f->media_image.size()>0 && (!f->isWritable || f->pathInStream.empty()) )
                     {
@@ -2786,6 +2786,25 @@ void iecDrive::consoleClose(uint8_t channel)
     close(channel);
 }
 
+void iecDrive::setStatusFileError(std::string &url)
+{
+    // An operation on a networked resource (scheme "://") that failed while
+    // WiFi is down means the drive is offline, not that the file/dir is
+    // missing. Report DRIVE NOT READY (74) so a client can tell "Meatloaf
+    // offline" from a genuinely absent target (62 FILE NOT FOUND). A real 404,
+    // or any local target, still reports FILE NOT FOUND.
+    if( mstr::contains(url, "://") && !fnWiFi.connected() )
+    {
+        Debug_printv("Error: network target, WiFi offline [%s]", url.c_str());
+        setStatusCode(ST_DRIVE_NOT_READY);
+    }
+    else
+    {
+        Debug_printv("Error: target doesn't exist [%s]", url.c_str());
+        setStatusCode(ST_FILE_NOT_FOUND);
+    }
+}
+
 
 bool iecDrive::hasError()
 {
@@ -3153,7 +3172,7 @@ void iecDrive::set_cwd(std::string path, bool verified)
             else
             {
                 Debug_printv("Could not create VDrive for URL %s", n->url.c_str());
-                setStatusCode(ST_FILE_NOT_FOUND);
+                setStatusFileError(n->url);
                 delete n;
             }
         }
@@ -3165,7 +3184,7 @@ void iecDrive::set_cwd(std::string path, bool verified)
         else
         {
             Debug_printv("invalid directory");
-            setStatusCode(ST_FILE_NOT_FOUND);
+            setStatusFileError(n->url);
             delete n;
         }
     }

--- a/lib/device/iec/drive.h
+++ b/lib/device/iec/drive.h
@@ -266,6 +266,10 @@ public:
   // the host is down or its certificate was rejected, and only the message
   // field can tell the two apart on the command channel.
   void    setStatusCode(uint8_t code, const std::string &msg);
+  // Set the failure status for an operation on `url` that couldn't complete:
+  // a networked resource (scheme "://") while WiFi is down is DRIVE NOT READY
+  // (the drive is offline), not a genuinely missing FILE NOT FOUND.
+  void    setStatusFileError(std::string &url);
   bool    hasError();
   bool    hasMemExeError();
 


### PR DESCRIPTION
A read or `cd` on a networked resource (a `://` scheme) that fails while WiFi is down isn't a missing file — the drive can't reach it. This adds `setStatusFileError()`, which returns **74 DRIVE NOT READY** instead of **62 FILE NOT FOUND** in that case, and calls it from `open()` and `set_cwd()`.

So a client can tell an offline Meatloaf from a genuinely absent target. A real 404, or any local target, still reports FILE NOT FOUND.

Tested on hardware (Freenove ESP32-S3) with a client shell: `load` of a network file and `cd` into a network folder both report DRIVE NOT READY while offline; missing local files still report FILE NOT FOUND.